### PR TITLE
 chore(docker): updated Dockerfile to handle skins folder creations 🐳

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ WORKDIR /app
 
 COPY log ./log
 COPY --from=builder /build/target/minecraft-clone-1.0-SNAPSHOT-jar-with-dependencies.jar .
+COPY server-config.json ./server-config.json
+
+RUN mkdir -p skins
 
 EXPOSE 50000/udp
 


### PR DESCRIPTION
Little update in the Dockerfile, it was missing the creation of the `skins/` folder in the container to let the server saves skin of an user connected to the server